### PR TITLE
Fix: no default favicon + no empty data

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getstation/fetch-favicon",
-  "version": "0.0.4-rc.0",
+  "version": "0.0.4-rc.1",
   "description": "Fetch a great looking favicon from a website",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getstation/fetch-favicon",
-  "version": "0.0.4-rc.1",
+  "version": "0.0.4-rc.2",
   "description": "Fetch a great looking favicon from a website",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@getstation/fetch-favicon",
-  "version": "0.0.3",
+  "version": "0.0.4-rc.0",
   "description": "Fetch a great looking favicon from a website",
   "main": "dist/index.js",
   "scripts": {

--- a/source/index.js
+++ b/source/index.js
@@ -21,7 +21,8 @@ const emptyDataContents = [
 ]
 
 function isEmptyData (favicon) {
-  return !favicon.href && emptyDataContents.includes(favicon.content)
+  if (favicon.href) return emptyDataContents.includes(favicon.href)
+  return emptyDataContents.includes(favicon.content)
 }
 
 function isNotEmptyData (favicon) {

--- a/source/index.js
+++ b/source/index.js
@@ -15,8 +15,13 @@ function getFavicons (url) {
   }])
 }
 
+const emptyDataContents = [
+  'data:/,',
+  'data:/'
+]
+
 function isEmptyData (favicon) {
-  return !favicon.href && favicon.content === 'data:/'
+  return !favicon.href && emptyDataContents.includes(favicon.content)
 }
 
 function isNotEmptyData (favicon) {

--- a/source/index.js
+++ b/source/index.js
@@ -1,7 +1,6 @@
 'use strict'
 
 const x = require('x-ray')()
-const Url = require('url')
 const config = require('./config')
 const markActiveFavicon = require('./markActiveFavicon').default
 
@@ -14,6 +13,14 @@ function getFavicons (url) {
     name: '@name',
     sizes: '@sizes'
   }])
+}
+
+function isEmptyData (favicon) {
+  return !favicon.href && favicon.content === 'data:/'
+}
+
+function isNotEmptyData (favicon) {
+  return !isEmptyData(favicon)
 }
 
 function setFetchFaviconTimeout (ms) {
@@ -38,12 +45,8 @@ function fetchFavicons (url, size) {
       if (err) {
         return reject(err)
       }
-      favicons.push({
-        href: Url.resolve(url, 'favicon.ico'),
-        name: 'favicon.ico'
-      })
 
-      favicons = favicons.map((favicon) => {
+      favicons = favicons.filter(isNotEmptyData).map((favicon) => {
         const f = {
           href: favicon.href || favicon.content,
           name: favicon.name || favicon.rel || favicon.property,


### PR DESCRIPTION
[**@getstation/fetch-favicon@0.0.4-rc2**](https://www.npmjs.com/package/@getstation/fetch-favicon/v/0.0.4-rc.2) released.

1. I removed default `favicon.ico` fallback because the result is random (for example, it does not work with google calendar)
2. I added a check to ignore with an empty data content (`data:/` and `data:/,`) (it should fix issues with forestapp)